### PR TITLE
Remove duplicate calls and make data service async

### DIFF
--- a/typescript/animal-rescue-mcp-server/src/animal-data.ts
+++ b/typescript/animal-rescue-mcp-server/src/animal-data.ts
@@ -1,4 +1,4 @@
-import { Animal } from './animal-rescue-service';
+import type { Animal } from './animal-rescue-service';
 
 export const ANIMALS_DATA: Animal[] = [
   {

--- a/typescript/animal-rescue-mcp-server/src/animal-rescue-service.ts
+++ b/typescript/animal-rescue-mcp-server/src/animal-rescue-service.ts
@@ -35,16 +35,16 @@ export type AdoptionCertificate = z.infer<typeof adoptionCertificateSchema>;
 export class AnimalRescueService {
   private animals: Animal[] = [...ANIMALS_DATA];
 
-  listAnimals(): Animal[] {
+  async listAnimals(): Promise<Animal[]> {
     return this.animals.filter(animal => !animal.adopted);
   }
 
-  getAnimalById(id: string): Animal | null {
+  async getAnimalById(id: string): Promise<Animal | null> {
     const animal = this.animals.find(animal => animal.id === id);
     return animal || null;
   }
 
-  getAnimalByName(name: string): Animal | null {
+  async getAnimalByName(name: string): Promise<Animal | null> {
     console.log("getAnimalByName", name);
 
 
@@ -55,7 +55,7 @@ export class AnimalRescueService {
     return animal || null;
   }
 
-  adoptAnimal(id: string): AdoptionCertificate | null {
+  async adoptAnimal(id: string): Promise<AdoptionCertificate | null> {
     const animal = this.animals.find(animal => animal.id === id);
     // return a new adoption certificate with a fake pickup location and curent time
     const pickupLocation = "123 Main St, Anytown, USA";

--- a/typescript/animal-rescue-mcp-server/src/completed-index.ts
+++ b/typescript/animal-rescue-mcp-server/src/completed-index.ts
@@ -31,14 +31,19 @@ export class MyMCP extends McpAgent {
 					animals: z.array(animalSchema)
 				}
 			},
-			async () => ({
-        // some clients dont yet support structured content, so we need to return text
-				content: [{
-          type: "text",
-          text: JSON.stringify(this.animalRescueService.listAnimals())
-        }],
-				structuredContent: { animals: this.animalRescueService.listAnimals() }
-			})
+			async () => {
+				const structuredContent = {
+					animals: await this.animalRescueService.listAnimals()
+				};
+				return {
+					// some clients dont yet support structured content, so we need to return text
+					content: [{
+						type: "text",
+						text: JSON.stringify(structuredContent)
+					}],
+					structuredContent
+				};
+			}
 		);
 
 		// Tool 2: get_animal_by_id
@@ -54,13 +59,18 @@ export class MyMCP extends McpAgent {
 					id: z.string()
 				}
 			},
-			async ({ id }) => ({
-				content: [{
-          type: "text",
-          text: JSON.stringify(this.animalRescueService.getAnimalById(id))
-        }],
-				structuredContent: { animal: this.animalRescueService.getAnimalById(id) }
-			})
+			async ({ id }) => {
+				const structuredContent = {
+					animal: await this.animalRescueService.getAnimalById(id)
+				};
+				return {
+					content: [{
+						type: "text",
+						text: JSON.stringify(structuredContent)
+					}],
+					structuredContent
+				};
+			}
 		);
 
 		// Tool 3: get_animal_by_name
@@ -76,13 +86,18 @@ export class MyMCP extends McpAgent {
 					name: z.string()
 				}
 			},
-			async ({ name }) => ({
-				content: [{
-          type: "text",
-          text: JSON.stringify(this.animalRescueService.getAnimalByName(name))
-        }],
-				structuredContent: { animal: this.animalRescueService.getAnimalByName(name) }
-			})
+			async ({ name }) => {
+				const structuredContent = {
+					animal: await this.animalRescueService.getAnimalByName(name)
+				};
+				return {
+					content: [{
+						type: "text",
+						text: JSON.stringify(structuredContent)
+					}],
+					structuredContent
+				};
+			}
 		);
 
 		// Tool 4: adopt_pet
@@ -100,18 +115,18 @@ export class MyMCP extends McpAgent {
 				}
 			},
 			async ({ id }) => {
-				var certificate = this.animalRescueService.adoptAnimal(id);
-				var success = certificate !== null;
+				const certificate = await this.animalRescueService.adoptAnimal(id);
+				const structuredContent = {
+					certificate,
+					success: certificate !== null
+				};
 				return {
 					content: [{
-            type: "text",
-            text: JSON.stringify({
-              certificate: certificate,
-              success: success
-            })
-          }],
-					structuredContent: { certificate: certificate, success: success }
-				}
+						type: "text",
+						text: JSON.stringify(structuredContent)
+					}],
+					structuredContent
+				};
 			}
 		);
 


### PR DESCRIPTION
Users typically won't have access to a synchronous data service, so this is a little more realistic (without adding too much difficulty)

Also just made sure we're only calling the service once per tool call.